### PR TITLE
Harambee/uat new auth server and all fixes from production branch

### DIFF
--- a/common/djangoapps/microsite_configuration/migrations/0004_merge.py
+++ b/common/djangoapps/microsite_configuration/migrations/0004_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('microsite_configuration', '0003_delete_historical_records'),
+        ('microsite_configuration', '0003_basicmicrosite'),
+    ]
+
+    operations = [
+    ]

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -682,17 +682,17 @@ def _has_access_to_course(user, access_level, course_key):
         debug("Deny: unknown access level")
         return ACCESS_DENIED
 
-    org_user = OrganizationUser.objects.filter(
-        active=True,
-        organization__short_name=course_key.org,
-        user_id=user.id
-    ).values().first()
+#    org_user = OrganizationUser.objects.filter(
+#        active=True,
+#        organization__short_name=course_key.org,
+#        user_id=user.id
+#    ).values().first()
 
-    staff_access = (
-        CourseStaffRole(course_key).has_user(user) or
-        OrgStaffRole(course_key.org).has_user(user) or
-        (org_user and org_user['is_staff'])
-    )
+#    staff_access = (
+#        CourseStaffRole(course_key).has_user(user) or
+#        OrgStaffRole(course_key.org).has_user(user) or
+#        (org_user and org_user['is_staff'])
+#    )
 
     if staff_access and access_level == 'staff':
         debug("Allow: user has course staff access")

--- a/lms/djangoapps/student_account/harambee.py
+++ b/lms/djangoapps/student_account/harambee.py
@@ -3,6 +3,7 @@ import json
 from student.models import Registration, UserProfile
 from social_core.backends.oauth import BaseOAuth2
 from django.contrib.auth.models import User
+from django.conf import settings
 import uuid
 import logging
 import social_django
@@ -26,15 +27,12 @@ class HarambeeOAuth2(BaseOAuth2):
     REDIRECT_STATE = False
     ID_KEY = 'username'
     STATE_PARAMETER = True
-    AUTHORIZATION_URL = \
-        'https://mvpdev.harambeecloud.com/identityserver/connect/authorize'
-    ACCESS_TOKEN_URL = \
-        'https://mvpdev.harambeecloud.com/identityserver/connect/token'
+    AUTHORIZATION_URL = settings.AUTHORIZATION_URL
+    ACCESS_TOKEN_URL = settings.ACCESS_TOKEN_URL
     ACCESS_TOKEN_METHOD = 'POST'
     RESPONSE_TYPE = 'code id_token'
     REDIRECT_IS_HTTPS = True
-    REVOKE_TOKEN_URL = \
-        'https://mvpdev.harambeecloud.com/identityserver/connect/endsession'
+    REVOKE_TOKEN_URL = settings.REVOKE_TOKEN_URL
     REVOKE_TOKEN_METHOD = 'GET'
 
     # The order of the default scope is important

--- a/lms/envs/aws.py
+++ b/lms/envs/aws.py
@@ -1099,3 +1099,8 @@ ACE_ROUTING_KEY = ENV_TOKENS.get('ACE_ROUTING_KEY', ACE_ROUTING_KEY)
 
 # Allow extra middleware classes to be added to the app through configuration.
 MIDDLEWARE_CLASSES.extend(ENV_TOKENS.get('EXTRA_MIDDLEWARE_CLASSES', []))
+
+AUTHORIZATION_URL = ENV_TOKENS.get('HARAMBEE_AUTHORIZATION_URL', 'https://mvpdev.harambeecloud.com/identityserver/connect/authorize')
+ACCESS_TOKEN_URL = ENV_TOKENS.get('HARAMBEE_ACCESS_TOKEN_URL', 'https://mvpdev.harambeecloud.com/identityserver/connect/token')
+REVOKE_TOKEN_URL = ENV_TOKENS.get('HARAMBEE_REVOKE_TOKEN_URL', 'https://mvpdev.harambeecloud.com/identityserver/connect/endsession')
+

--- a/openedx/core/djangoapps/content/course_overviews/migrations/0015_auto_20180704_1004.py
+++ b/openedx/core/djangoapps/content/course_overviews/migrations/0015_auto_20180704_1004.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('course_overviews', '0014_courseoverview_certificate_available_date'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='_pre_requisite_courses_json',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='advertised_start',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='announcement',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='catalog_visibility',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='cert_name_long',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='cert_name_short',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='certificates_display_behavior',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='course_image_url',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='course_video_url',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='days_early_for_beta',
+            field=models.FloatField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='effort',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='end_of_course_survey_url',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='enrollment_domain',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='enrollment_end',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='enrollment_start',
+            field=models.DateTimeField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='lowest_passing_grade',
+            field=models.DecimalField(null=True, max_digits=5, decimal_places=2, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='max_student_enrollments_allowed',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='short_description',
+            field=models.TextField(null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='courseoverview',
+            name='social_sharing_url',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -46,7 +46,7 @@ edx-lint==0.4.3
 # when upgrading edx-lint, we should try to remove this from the platform
 astroid==1.3.8
 edx-django-sites-extensions==2.3.0
-edx-enterprise==0.52.3
+edx-enterprise==0.36.5
 edx-oauth2-provider==1.2.2
 edx-opaque-keys==0.4.0
 git+https://github.com/proversity-org/edx-organizations.git#egg=edx-organizations


### PR DESCRIPTION
What is merged:
- new SSO auth configuration (with defaults):
```
server-vars.yml:
EDXAPP_ENV_EXTRA:
  HARAMBEE_AUTHORIZATION_URL: 'https://some-new-endpoint/identityserver/connect/authorize'
  HARAMBEE_ACCESS_TOKEN_URL: 'https://some-new-endpoint/identityserver/connect/token'
  HARAMBEE_REVOKE_TOKEN_URL: 'https://some-new-endpoint/identityserver/connect/endsession'
```
- changes from production branch:
1. [Migrations](https://github.com/harambee-sa/edx-platform/pull/9)
2. [Downgrade for edx-enterprise module](https://github.com/harambee-sa/edx-platform/pull/8)
3. [Fix for excessive MySQL requests for SSO-logged users](https://github.com/harambee-sa/edx-platform/pull/10)